### PR TITLE
Include exported struct methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # typecover
 
-`typecover` is a go linter that checks if a code block is assigning to all exported fields of a struct or 
-calling all exported methods of an interface.
+`typecover` is a go linter that checks if a code block is assigning to all exported fields
+and calling all exported methods of a struct, or calling all exported methods of an interface.
 
 It is useful in cases where code wants to be aware of any newly added members.
 

--- a/testdata/src/structs/structs.go
+++ b/testdata/src/structs/structs.go
@@ -19,6 +19,29 @@ type MyEmbeddedStruct struct {
 	MyField4 string
 }
 
+type MyStructWithMethods struct {
+	MyField string
+}
+
+func (m MyStructWithMethods) ValueMethod() int {
+	return 0
+}
+func (m *MyStructWithMethods) PointerMethod() int {
+	return 0
+}
+
+type MyEmbeddedStructWithMethods struct {
+	MyStructWithMethods
+}
+
+func (m MyEmbeddedStructWithMethods) ValueMethod2() int {
+	return 0
+}
+
+func (m *MyEmbeddedStructWithMethods) PointerMethod2() int {
+	return 0
+}
+
 // typecover:MyStruct
 func testBlockPass() {
 	m := MyStruct{}
@@ -173,5 +196,45 @@ func testStructs() {
 	// typecover:MyStruct
 	_ = &MyStruct{ // want `Type structs.MyStruct is missing MyField1`
 		MyField2: "world",
+	}
+
+	// typecover:MyStructWithMethods
+	{
+
+		m := &MyStructWithMethods{
+			MyField: "",
+		}
+		_ = m.ValueMethod()
+		_ = m.PointerMethod()
+	}
+
+	// typecover:MyStructWithMethods
+	_ = &MyStructWithMethods{ // want `Type structs.MyStructWithMethods is missing ValueMethod, PointerMethod`
+		MyField: "",
+	}
+
+	//typecover:MyEmbeddedStructWithMethods
+	{
+		m := &MyEmbeddedStructWithMethods{
+			MyStructWithMethods: MyStructWithMethods{
+				MyField: "",
+			},
+		}
+		_ = m.PointerMethod()
+		_ = m.PointerMethod2()
+		_ = m.ValueMethod()
+		_ = m.ValueMethod2()
+	}
+
+	//typecover:MyEmbeddedStructWithMethods
+	{ // want `Type structs.MyEmbeddedStructWithMethods is missing PointerMethod`
+		m := &MyEmbeddedStructWithMethods{
+			MyStructWithMethods: MyStructWithMethods{
+				MyField: "",
+			},
+		}
+		_ = m.PointerMethod2()
+		_ = m.ValueMethod()
+		_ = m.ValueMethod2()
 	}
 }

--- a/typecover.go
+++ b/typecover.go
@@ -63,6 +63,18 @@ func run(pass *analysis.Pass) (interface{}, error) {
 func checkMembers(pass *analysis.Pass, n ast.Node, target types.Type, exclude []string) []string {
 	membersFound := map[string]bool{}
 
+	for _, t := range []types.Type{target, types.NewPointer(target)} {
+		mset := types.NewMethodSet(t)
+		for i := 0; i < mset.Len(); i++ {
+			switch u := mset.At(i).Obj().(type) {
+			case *types.Func:
+				if u.Exported() {
+					membersFound[u.Name()] = false
+				}
+			}
+		}
+	}
+
 	switch u := target.Underlying().(type) {
 	case *types.Interface:
 		for i := 0; i < u.NumMethods(); i++ {


### PR DESCRIPTION
This analyzer is great at supporting Builders where the builder is an interface and you're trying to clone an object via that builder. If that builder is a concrete type, that same pattern doesn't work though, because we're only taking methods from interface types. Include methods on concrete structs as well, so we can catch those kinds of problems!