### PR TITLE
Handle imports with dots in them

### DIFF
--- a/testdata/src/structs/importwithdot.go
+++ b/testdata/src/structs/importwithdot.go
@@ -1,0 +1,22 @@
+package structs
+
+import (
+	"myvendor.org/somepkg"
+)
+
+// typecover:somepkg.Foo
+func testImportPathWithDotSuccess() {
+	f := &somepkg.Foo{
+		Bar: "bar",
+		Baz: "baz",
+	}
+	_ = f
+}
+
+// typecover:somepkg.Foo
+func testImportPathWithDotFailure() { // want `Type myvendor.org/somepkg.Foo is missing Baz`
+	f := &somepkg.Foo{
+		Bar: "bar",
+	}
+	_ = f
+}

--- a/testdata/src/structs/vendor/myvendor.org/somepkg/somepkg.go
+++ b/testdata/src/structs/vendor/myvendor.org/somepkg/somepkg.go
@@ -1,0 +1,6 @@
+package somepkg
+
+type Foo struct {
+	Bar string
+	Baz string
+}


### PR DESCRIPTION
Most third-party dependencies have a dot in the import path (ie "github.com/someuser/somerepo"). Typecover was assuming a dot meant "separate between the package name and the type name", but only the last dot means that. Handle things accordingly!

This also required a bit of change to the package name matching to handle vendor directories, since analysistest operates on GOPATH-style packages.